### PR TITLE
feat: add support for webpack 4 and 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ before_script:
   - npm install node-sass sass-extract
 
 node_js:
-  - "6"
-  - "5"
+  - "10"
 
 env:
-  - WEBPACK_VERSION=^1.12.6"
-  - WEBPACK_VERSION=^2
-  - WEBPACK_VERSION=^3
+  - WEBPACK_VERSION=^4
+  - WEBPACK_VERSION=^5

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=4"
   },
   "peerDependencies": {
-    "webpack": "^3 || ^2 || ^2.2.0-rc.0 || ^2.1.0-beta || ^1.12.6",
+    "webpack": "^5 || ^4",
     "sass-extract": "^1.0.1 || ^2.0.0"
   },
   "devDependencies": {
@@ -34,7 +34,7 @@
     "chai": "^4.1.2",
     "cz-conventional-changelog": "^2.1.0",
     "mocha": "^4.0.1",
-    "webpack": "^3.9.1"
+    "webpack": "5.20.1"
   },
   "config": {
     "commitizen": {
@@ -42,6 +42,6 @@
     }
   },
   "dependencies": {
-    "loader-utils": "^1.1.0"
+    "loader-utils": "^2.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,7 @@ describe('sass-vars-loader', () => {
       expect(compiled.global.$e.sources).to.have.members([source]);
       expect(compiled.global.$f.sources).to.have.members([source]);
 
-      expect(stats.compilation.fileDependencies).to.have.members([source]);
+      expect(Array.from(stats.compilation.fileDependencies)).to.include.members([source]);
     });
   });
 
@@ -46,7 +46,7 @@ describe('sass-vars-loader', () => {
       expect(compiled.global.$e.sources).to.have.members([sourceSub2]);
       expect(compiled.global.$f.sources).to.have.members([sourceSub2]);
 
-      expect(stats.compilation.fileDependencies).to.have.members([sourceRoot, sourceSub1, sourceSub2]);
+      expect(Array.from(stats.compilation.fileDependencies)).to.include.members([sourceRoot, sourceSub1, sourceSub2]);
     });
   });
 
@@ -54,7 +54,7 @@ describe('sass-vars-loader', () => {
     return runTest('./scss/error.scss')
     .catch(err => {
       const source = path.resolve(__dirname, './scss/error.scss');
-      expect(err.stats.compilation.fileDependencies).to.have.members([source]);
+      expect(Array.from(err.stats.compilation.fileDependencies)).to.include.members([source]);
     });
   });
 
@@ -63,12 +63,12 @@ describe('sass-vars-loader', () => {
     .catch(err => {
       const sourceRoot = path.resolve(__dirname, './scss/nested-error.scss');
       const sourceSub = path.resolve(__dirname, './scss/sub/error.scss');
-      expect(err.stats.compilation.fileDependencies).to.have.members([sourceRoot, sourceSub]);
+      expect(Array.from(err.stats.compilation.fileDependencies)).to.include.members([sourceRoot, sourceSub]);
     });
   });
 
   it('should succesfully include files from includePaths', () => {
-    return runTest('./scss/include.scss', '?{"includePaths": ["./test/scss/include"]}')
+    return runTest('./scss/include.scss', {"includePaths": ["./test/scss/include"]})
     .then(results => {
       const compiled = results.compiled;
       const stats = results.stats;
@@ -80,12 +80,12 @@ describe('sass-vars-loader', () => {
       const sourceRoot = path.resolve(__dirname, './scss/include.scss');
       const sourceIncluded = path.resolve(__dirname, './scss/include/included.scss');
 
-      expect(stats.compilation.fileDependencies).to.have.members([sourceRoot, sourceIncluded]);
+      expect(Array.from(stats.compilation.fileDependencies)).to.include.members([sourceRoot, sourceIncluded]);
     });
   });
 
   it('should succesfully use minimal plugin', () => {
-    return runTest('./scss/basic.scss', '?{"plugins": ["minimal"]}')
+    return runTest('./scss/basic.scss', {"plugins": ["minimal"]})
     .then(results => {
       const compiled = results.compiled;
       const stats = results.stats;
@@ -101,7 +101,7 @@ describe('sass-vars-loader', () => {
       expect(compiled.global.$d).to.equal('1px solid black');
       expect(compiled.global.$e).to.equal('string');
 
-      expect(stats.compilation.fileDependencies).to.have.members([source]);
+      expect(Array.from(stats.compilation.fileDependencies)).to.include.members([source]);
     });
   });
 });

--- a/test/run-test.js
+++ b/test/run-test.js
@@ -3,17 +3,19 @@ const webpack = Promise.promisify(require('webpack'));
 const path = require('path');
 
 const pathToLoader = path.resolve(__dirname, "../index.js");
-const pathToTestBundle = path.resolve(__dirname, "./output/test.bundle.js")
+const pathToTestBundle = path.resolve(__dirname, "./output/test.bundle.js");
 
 module.exports = exports = (filename, options) => {
   return webpack({
     entry: filename,
     context: __dirname,
+    mode: 'development',
     module: {
-      loaders: [
+      rules: [
         {
           test: /.scss$/,
-          loader: pathToLoader + (options || ''),
+          loader: pathToLoader,
+          options
         }
       ],
     },


### PR DESCRIPTION
BREAKING CHANGE: drop support for webpack 1-3

- upgrade to loader-utils
- add support for webpack 4 & webpack 5
- webpack is now using `Set` instead of `Array` therefore the unit tests had to be adjusted