### PR TITLE
Support of Dart Sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,12 +16,17 @@ module.exports = exports = function sassExtractLoader(content) {
 
   const query = loaderUtils.getOptions(this);;
   const plugins = (query ? query.plugins : []) || [];
+  const extractOptions = { plugins };
 
-  return sassExtract.render(Object.assign({}, query, { file: this.resourcePath }), { plugins })
+  if (query.implementation) {
+    extractOptions.implementation = query.implementation;
+  }
+
+  return sassExtract.render(Object.assign({}, query, { file: this.resourcePath }), extractOptions)
   .then(rendered => {
     this.value = [rendered.vars];
     const result = `module.exports = ${JSON.stringify(rendered.vars)};`;
-    
+
     rendered.stats.includedFiles.forEach(includedFile => {
       this.addDependency(normalizeDependency(includedFile));
     });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "webpack": "^3 || ^2 || ^2.2.0-rc.0 || ^2.1.0-beta || ^1.12.6",
-    "sass-extract": "^1.0.1 || ^2.0.0"
+    "sass-extract": "^1.0.1 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "bluebird": "^3.4.7",


### PR DESCRIPTION
Hello,

this PR adds an option named `implementation` to allow the selection of dart sass when using sass-extract@3.0.0

